### PR TITLE
fixed: 关联表查询修复

### DIFF
--- a/scripts/amis/lib.js
+++ b/scripts/amis/lib.js
@@ -491,7 +491,7 @@ function updateFormRelations(schemas, model, actionType) {
       },
     });
   }
-  if (Object.keys(hasManys).length > 1) {
+  if (Object.keys(hasManys).length >= 1) {
     const tabs = {
       label: "关联表",
       type: "static-tabs",


### PR DESCRIPTION
## 简介
当前情况必须设置两个以上的havemany关联才能显示。
修复后，一个也可以显示